### PR TITLE
Changed downcast code to use df[cols] instead of df.loc[:, cols]

### DIFF
--- a/nfl_data_py/__init__.py
+++ b/nfl_data_py/__init__.py
@@ -134,7 +134,7 @@ def import_pbp_data(years, columns=None, include_participation=True, downcast=Tr
     if downcast:
         print('Downcasting floats.')
         cols = plays.select_dtypes(include=[numpy.float64]).columns
-        plays.loc[:, cols] = plays.loc[:, cols].astype(numpy.float32)
+        plays[cols] = plays[cols].astype(numpy.float32)
             
     return plays
 
@@ -199,7 +199,7 @@ def cache_pbp(years, downcast=True, alt_path=None):
 
             if downcast:
                 cols = raw.select_dtypes(include=[numpy.float64]).columns
-                raw.loc[:, cols] = raw.loc[:, cols].astype(numpy.float32)
+                raw[cols] = raw[cols].astype(numpy.float32)
 
             # write parquet to path, partitioned by season
             raw.to_parquet(path, partition_cols='season')
@@ -242,7 +242,7 @@ def import_weekly_data(years, columns=None, downcast=True):
     if downcast:
         print('Downcasting floats.')
         cols = data.select_dtypes(include=[numpy.float64]).columns
-        data.loc[:, cols] = data.loc[:, cols].astype(numpy.float32)
+        data[cols] = data[cols].astype(numpy.float32)
 
     return data
 


### PR DESCRIPTION
pandas was giving me the following FutureWarning when importing data:
```
/nfl_data_py/__init__.py:137: FutureWarning: In a future version, `df.iloc[:, i] = newvals` will attempt
to set the values inplace instead of always setting a new array. To retain the old behavior, use either
`df[df.columns[i]] = newvals` or, if columns are non-unique, `df.isetitem(i, newvals)`
    plays.loc[:, cols] = plays.loc[:, cols].astype(numpy.float32)
```

This change seems to have eliminated the warning.