### PR TITLE
Added thread_requests parameter to import_pbp_data and import_weekly …

### DIFF
--- a/nfl_data_py/__init__.py
+++ b/nfl_data_py/__init__.py
@@ -101,7 +101,15 @@ def import_pbp_data(
             # Create a list of the same size as years, initialized with None
             pbp_data = [None]*len(years)
             # Create a mapping of futures to their corresponding index in the pbp_data
-            futures_map = {executor.submit(pandas.read_parquet, path=url1 + str(year) + url2, columns=columns if columns else None, engine='auto'): idx for idx, year in enumerate(years)}
+            futures_map = {
+                executor.submit(
+                    pandas.read_parquet,
+                    path=url1 + str(year) + url2,
+                    columns=columns if columns else None, 
+                    engine='auto'
+                ): idx 
+                for idx, year in enumerate(years)
+            }
             for future in as_completed(futures_map):
                 pbp_data[futures_map[future]] = future.result()
     else:

--- a/nfl_data_py/__init__.py
+++ b/nfl_data_py/__init__.py
@@ -265,7 +265,15 @@ def import_weekly_data(
             # Create a list of the same size as years, initialized with None
             data = [None]*len(years)
             # Create a mapping of futures to their corresponding index in the data
-            futures_map = {executor.submit(pandas.read_parquet, path=url.format(year), columns=columns if columns else None, engine='auto'): idx for idx, year in enumerate(years)}
+            futures_map = {
+                executor.submit(
+                    pandas.read_parquet,
+                    path=url.format(year),
+                    columns=columns if columns else None,
+                    engine='auto'
+                ): idx
+                for idx, year in enumerate(years)
+            }
             for future in as_completed(futures_map):
                 data[futures_map[future]] = future.result()
             data = pandas.concat(data)

--- a/nfl_data_py/tests/nfl_test.py
+++ b/nfl_data_py/tests/nfl_test.py
@@ -8,10 +8,20 @@ class test_pbp(TestCase):
         s = nfl.import_pbp_data([2020])
         self.assertEqual(True, isinstance(s, pd.DataFrame))
         self.assertTrue(len(s) > 0)
+
+    def test_is_df_with_data_thread_requests(self):
+        s = nfl.import_pbp_data([2020, 2021], thread_requests=True)
+        self.assertEqual(True, isinstance(s, pd.DataFrame))
+        self.assertTrue(len(s) > 0)
 		
 class test_weekly(TestCase):
     def test_is_df_with_data(self):
         s = nfl.import_weekly_data([2020])
+        self.assertEqual(True, isinstance(s, pd.DataFrame))
+        self.assertTrue(len(s) > 0)
+
+    def test_is_df_with_data_thread_requests(self):
+        s = nfl.import_weekly_data([2020, 2021], thread_requests=True)
         self.assertEqual(True, isinstance(s, pd.DataFrame))
         self.assertTrue(len(s) > 0)
         

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,7 @@ REQUIRED = [
     'pandas>1',
     'appdirs>1',
     'fastparquet>0.5',
-    'python-snappy>0.5',
-    'pyarrow>1',
+    'python-snappy>0.5'
 ]
 
 # What packages are optional?

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ REQUIRED = [
     'pandas>1',
     'appdirs>1',
     'fastparquet>0.5',
-    'python-snappy>0.5'
+    'python-snappy>0.5',
+    'pyarrow>1',
 ]
 
 # What packages are optional?


### PR DESCRIPTION
…data functions.

Added optional parameter to import_pbp_data and import_weekly_data to use threading to speed up requests for play by play data and weekly data. I also tested async and multiprocessing as well but threading posted the best results. Depending on connection, it sped up the speed at which PBP data from 1999 to 2022 was loaded by 25-50%. 

Also added associated tests. I added a __init__.py file to the tests folder, because it was the only way I could run pytest (although I may have done something wrong there).

Did not open issue for this beforehand but spoke to @cooperdff on Twitter about the idea and thought it was a good idea. 

Test results below:

![image](https://user-images.githubusercontent.com/59814501/233640445-099d31c9-7c2d-444e-aa75-127c29bb09e6.png)

