### PR TITLE
Split import_pfr() into seasonal and weekly methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,10 +242,22 @@ frequency
 : optional, frequency to return data for, weekly or season, default season
 
 ```python
-nfl.import_pfr(s_type, years)
+nfl.import_seasonal_pfr(s_type, years)
 ```
 
-Returns dataframe of data sourced from https://www.pro-football-reference.com/
+Returns a dataframe of season-aggregated data sourced from players' pages on pro-football-reference.com. E.g. [Patrick Mahomes](https://www.pro-football-reference.com/players/M/MahoPa00.htm#all_passing_detailed)
+
+s_type (str)
+: required, the type of stat data to request. Must be one of pass, rec, or rush.
+
+years (List[int])
+: optional, years to return data for
+
+```python
+nfl.import_weekly_pfr(s_type, years)
+```
+
+Returns a dataframe of per-game data sourced from players' advanced gamelog pages on pro-football-reference.com. E.g. [Mahomes in 2022](https://www.pro-football-reference.com/players/M/MahoPa00/gamelog/2022/advanced/#all_advanced_passing)
 
 s_type (str)
 : required, the type of stat data to request. Must be one of pass, rec, or rush.

--- a/nfl_data_py/__init__.py
+++ b/nfl_data_py/__init__.py
@@ -863,10 +863,6 @@ def import_weekly_pfr(s_type, years=None):
     return df[df.season.isin(years)] if years else df
     
     
-    # url = r'https://github.com/nflverse/nflverse-data/releases/download/pfr_advstats/advstats_week_{0}_{1}.parquet'
-    # df = pandas.concat([pandas.read_parquet(url.format(s_type, x), engine='auto') for x in years])
-    
-    
 def import_snap_counts(years):
     """Import snap count data for individual players
     

--- a/nfl_data_py/__init__.py
+++ b/nfl_data_py/__init__.py
@@ -24,7 +24,8 @@ import_seasonal_data() - import seasonal player stats
 import_snap_counts() - import weekly snap count stats
 import_ngs_data() - import NGS advanced analytics
 import_qbr() - import QBR for NFL or college
-import_pfr() - import advanced passing stats from PFR
+import_seasonal_pfr() - import advanced stats from PFR on a seasonal basis
+import_weekly_pfr() - import advanced stats from PFR on a weekly basis
 import_officials() - import details on game officials
 import_schedules() - import weekly teams schedules
 import_rosters() - import team rosters

--- a/nfl_data_py/tests/nfl_test.py
+++ b/nfl_data_py/tests/nfl_test.py
@@ -122,11 +122,54 @@ class test_qbr(TestCase):
         self.assertEqual(True, isinstance(s, pd.DataFrame))
         self.assertTrue(len(s) > 0)
         
-class test_pfr(TestCase):
+class test_seasonal_pfr(TestCase):
+    df = nfl.import_seasonal_pfr('pass')
+    
     def test_is_df_with_data(self):
-        s = nfl.import_pfr('pass')
-        self.assertEqual(True, isinstance(s, pd.DataFrame))
-        self.assertTrue(len(s) > 0)
+        self.assertIsInstance(self.df, pd.DataFrame)
+        self.assertTrue(len(self.df) > 0)
+        
+    def test_contains_one_row_per_player_per_season(self):
+        pat = get_pat(self.df)
+        self.assertCountEqual(pat.season, pat.season.unique())
+        
+    def test_contains_seasonal_exclusive_columns(self):
+        self.assertIn("rpo_plays", self.df.columns)
+    
+    def test_retrieves_all_available_years_by_default(self):
+        available_years = pd.read_parquet(
+            "https://github.com/nflverse/nflverse-data/releases/download/pfr_advstats/advstats_season_pass.parquet"
+        ).season.unique()
+        self.assertCountEqual(self.df.season.unique(), available_years)
+        
+    def test_filters_by_year(self):
+        only_20_21 = nfl.import_seasonal_pfr('pass', [2020, 2021])
+        self.assertCountEqual(only_20_21.season.unique(), [2020, 2021])
+        
+class test_weekly_pfr(TestCase):
+    df = nfl.import_weekly_pfr('pass')
+    
+    def test_is_df_with_data(self):
+        self.assertIsInstance(self.df, pd.DataFrame)
+        self.assertTrue(len(self.df) > 0)
+        
+    def test_contains_one_row_per_player_per_week(self):
+        weeks_per_season = get_pat(self.df).groupby("season").week.nunique()
+        self.assertEqual(weeks_per_season.to_list(), [18, 17, 18, 20, 20])
+        
+    def test_does_not_contain_seasonal_exclusive_columns(self):
+        self.assertNotIn("rpo_plays", self.df.columns)
+    
+    def test_retrieves_all_available_years_by_default(self):
+        available_years = pd.read_parquet(
+            "https://github.com/nflverse/nflverse-data/releases/download/pfr_advstats/advstats_season_pass.parquet"
+        ).season.unique()
+        self.assertCountEqual(self.df.season.unique(), available_years)
+        
+    def test_filters_by_year(self):
+        only_20_21 = nfl.import_weekly_pfr('pass', [2020, 2021])
+        self.assertCountEqual(only_20_21.season.unique(), [2020, 2021])
+    
         
 class test_snaps(TestCase):
     def test_is_df_with_data(self):
@@ -152,3 +195,15 @@ class test_players(TestCase):
         self.assertEqual(True, isinstance(s, pd.DataFrame))
         self.assertTrue(len(s) > 0)
 
+
+# ---------------------------- Helper Functions -------------------------------
+def __get_player(df: pd.DataFrame, player_name: str):
+    player_name_cols = ('player_name', 'player', 'pfr_player_name')
+    player_name_col = set(player_name_cols).intersection(set(df.columns)).pop()
+    return df[df[player_name_col] == player_name]
+
+def get_pat(df):
+    return __get_player(df, 'Patrick Mahomes')
+
+def get_hock(df):
+    return __get_player(df, 'T.J. Hockenson')


### PR DESCRIPTION
Resolves https://github.com/cooperdff/nfl_data_py/issues/53.

Additionally, I bumped the minimum year check back to 2018 as it seems that data is available in the nflverse-data release now.